### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=arduino-snmp
+version=0.0.1
+author=Bram van der Kroef
+maintainer=Bram van der Kroef
+sentence=SNMP library for Arduino.
+paragraph=
+category=Communication
+url=https://github.com/BramvdKroef/arduino-snmp
+architectures=*
+includes=snmp.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the Arduino Library Manager index.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata